### PR TITLE
fetch and display individual test results

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,31 +1,16 @@
 import { Routes, Route } from "react-router-dom";
 import Home from "./components/Home";
 import CreateTest from "./components/CreateTest";
-import { useState, useEffect } from 'react';
-import apiClient from './services/ApiClient';
+import TestResults from "./components/TestResults";
 
 const App = () => {
-  const [scheduledTests, setScheduledTests] = useState([])
-
- 
-  useEffect( () => {
-    const populateScheduledTests = async () => {
-      try { 
-        const tests = await apiClient.getTests();
-        setScheduledTests(tests);
-      } catch (err) {
-        console.log(err)
-      }
-    };
-
-    populateScheduledTests();
-  }, [])
 
   return (
     <div>
       <Routes>
-        <Route path="/" element={<Home scheduledTests={scheduledTests}/>}></Route>
-        <Route index element={<Home scheduledTests={scheduledTests}/>}></Route>
+        <Route path="/" element={<Home />}></Route>
+        <Route index element={<Home />}></Route>
+        <Route path="/tests/:id" element={<TestResults />}></Route>
         <Route path="/create/test" element={<CreateTest />}></Route>
       </Routes>
     </div>

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,6 +1,20 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import apiClient from "../services/ApiClient";
+import TestRow from "./TestRow";
 
 const Home = ({ scheduledTests }) => {
+  const [tests, setTests] = useState([]);
+
+  const getAllTestsHook = () => {
+    const run = async () => {
+      const tests = await apiClient.getTests()
+      setTests(tests);
+    }
+    run();
+  }
+
+  useEffect(getAllTestsHook, [])
 
   return (
     <div>
@@ -15,12 +29,7 @@ const Home = ({ scheduledTests }) => {
           </tr> 
         </thead>
         <tbody>
-          {scheduledTests.map((test, idx) => (
-            <tr key={test.id}>
-              <td>{test.name}</td>
-              <td>{test.url}</td>
-            </tr>
-          ))}
+            { tests.map(test => <TestRow key={test.id} data={test}/>)}   
         </tbody>
       </table>
     </div>

--- a/src/components/TestResults.js
+++ b/src/components/TestResults.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useState, useEffect } from 'react';
+import apiClient from '../services/ApiClient';
+import { Link, useParams } from "react-router-dom";
+
+
+const TestResults = () => {
+  const testId = useParams().id;
+
+  const [results, setResults] = useState([]);
+
+  const getTestHook = () => {
+    const run = async () => {
+      try {
+        const test = await apiClient.getTest(testId);
+        console.log("test: ", test);
+        setResults(test)
+      } catch (err) {
+        console.log(err);
+      }
+    }
+    run();
+  }
+
+  useEffect(getTestHook, [])
+
+  return (
+    <div>
+      <Link to="/">
+        <button>Home</button>
+      </Link>
+      <h1>TestsResults</h1>
+
+    {results.map((item)=>{
+      return (
+        <div key={item.id}> {JSON.stringify(item)}</div>
+      )
+    })}
+    </div>
+  )
+}
+
+export default TestResults;

--- a/src/components/TestRow.js
+++ b/src/components/TestRow.js
@@ -1,0 +1,14 @@
+import { Link } from "react-router-dom";
+
+const TestRow = ({ data} ) => {
+  return (
+    <tr>    
+      <Link to={`/tests/${data.id}`}>
+        <td>{data.name}</td>
+        <td>{data.url}</td>   
+      </Link>
+    </tr>
+  )
+}
+
+export default TestRow;

--- a/src/services/ApiClient.js
+++ b/src/services/ApiClient.js
@@ -1,7 +1,6 @@
 import axios from "axios";
 
 const URL = "http://testscrud-env.eba-fpb5kcf8.us-east-1.elasticbeanstalk.com";
-const testURL = "http://localhost:5001"; //for local testing
 
 function logError(errorResponse) {
   const response = errorResponse.response;
@@ -16,7 +15,7 @@ function logError(errorResponse) {
 const apiClient = {
   createTest: async (test) => {
     try {
-      const { data } = await axios.post(`${testURL}/api/tests`, test);
+      const { data } = await axios.post(`${URL}/api/tests`, test);
       return data;
     } catch (e) {
       logError(e);
@@ -24,7 +23,15 @@ const apiClient = {
   },
   getTests: async () => {
     try {
-      const { data } = await axios.get(`${testURL}/api/tests`);
+      const { data } = await axios.get(`${URL}/api/tests`);
+      return data; 
+    } catch (e) {
+      logError(e);
+    }
+  },
+  getTest: async (id) => {
+    try {
+      const { data } = await axios.get(`${URL}/api/tests/${id}`);
       return data; 
     } catch (e) {
       logError(e);


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

* Adds links to each test name on the home page 
* Clicking on a test name redirects to a results page for that test, which currently displays raw test run / assertion results data, as shown below

<img width="450" alt="Screen Shot 2022-07-13 at 4 45 43 PM" src="https://user-images.githubusercontent.com/30358327/178855929-3f29166f-0464-44a6-a3ce-397322a8b9ed.png">

<img width="963" alt="Screen Shot 2022-07-13 at 4 45 35 PM" src="https://user-images.githubusercontent.com/30358327/178855940-0a2a3652-0068-45b5-8802-da773b063b55.png">


